### PR TITLE
Windows向けのマルチバイト処理を追加した

### DIFF
--- a/crates/open_jtalk/Cargo.toml
+++ b/crates/open_jtalk/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "open_jtalk"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 
 [dependencies]
 open_jtalk-sys = { path = "../open_jtalk-sys", version = "0.15.111" }
 thiserror = "1.0.31"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+local-encoding = "0.2.0"
+windows = { version = "0.39.0", features = ["Win32_Globalization"] }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/crates/open_jtalk/src/lib.rs
+++ b/crates/open_jtalk/src/lib.rs
@@ -4,6 +4,9 @@ mod njd;
 mod resource;
 mod text2mecab;
 
+#[cfg(target_os = "windows")]
+mod win_api_helper;
+
 pub use jpcommon::*;
 pub use mecab::*;
 pub use njd::*;

--- a/crates/open_jtalk/src/mecab/mod.rs
+++ b/crates/open_jtalk/src/mecab/mod.rs
@@ -37,7 +37,17 @@ impl Mecab {
     }
 
     pub fn load(&mut self, dic_dir: impl AsRef<Path>) -> bool {
-        let dic_dir = CString::new(dic_dir.as_ref().to_str().unwrap()).unwrap();
+        let path_str = dic_dir.as_ref().to_str().unwrap();
+        #[cfg(target_os = "windows")]
+        let dic_dir = {
+            if let Ok(s) = win_api_helper::str_to_local_multi_byte_string(path_str) {
+                s
+            } else {
+                return false;
+            }
+        };
+        #[cfg(not(target_os = "windows"))]
+        let dic_dir = CString::new(path_str).unwrap();
         unsafe {
             bool_number_to_bool(open_jtalk_sys::Mecab_load(
                 self.as_raw_ptr(),

--- a/crates/open_jtalk/src/win_api_helper.rs
+++ b/crates/open_jtalk/src/win_api_helper.rs
@@ -1,0 +1,8 @@
+use std::ffi::CString;
+
+pub fn str_to_local_multi_byte_string(s: &str) -> Result<CString, std::io::Error> {
+    let cp = unsafe { windows::Win32::Globalization::GetACP() };
+    Ok(unsafe {
+        CString::from_vec_unchecked(local_encoding::windows::string_to_multibyte(cp, s, None)?)
+    })
+}


### PR DESCRIPTION
Mecab_loadがWindowsだと文字エンコードの違いにより読み込めないのでlocaleによってMultibyte文字列を変換する処理を入れた

refs https://github.com/VOICEVOX/voicevox_core/pull/208#discussion_r930838316