### PR TITLE
`MaybeUninit::uninit().assume_init()`を撲滅し、Clippyを通す

### DIFF
--- a/crates/open_jtalk-sys/build.rs
+++ b/crates/open_jtalk-sys/build.rs
@@ -45,7 +45,7 @@ fn generate_bindings(include_dir: impl AsRef<Path>) {
         .size_t_is_usize(true)
         .rustfmt_bindings(true)
         .rustified_enum("*");
-    let paths = std::fs::read_dir(&include_dir).unwrap();
+    let paths = std::fs::read_dir(include_dir).unwrap();
     for path in paths {
         let path = path.unwrap();
         let file_name = path.file_name().to_str().unwrap().to_string();

--- a/crates/open_jtalk/src/jpcommon.rs
+++ b/crates/open_jtalk/src/jpcommon.rs
@@ -17,9 +17,11 @@ unsafe impl resources::Resource for JpCommon {
         if self.0.is_some() {
             panic!("already initialized jpcommon");
         }
-        #[allow(clippy::uninit_assumed_init)]
-        let mut jpcommon: open_jtalk_sys::JPCommon = MaybeUninit::uninit().assume_init();
-        open_jtalk_sys::JPCommon_initialize(&mut jpcommon);
+        let jpcommon = {
+            let mut jpcommon = MaybeUninit::<open_jtalk_sys::JPCommon>::uninit();
+            open_jtalk_sys::JPCommon_initialize(jpcommon.as_mut_ptr());
+            jpcommon.assume_init()
+        };
         self.0 = Some(jpcommon);
         true
     }

--- a/crates/open_jtalk/src/mecab/mod.rs
+++ b/crates/open_jtalk/src/mecab/mod.rs
@@ -15,9 +15,11 @@ unsafe impl resources::Resource for Mecab {
         if self.0.is_some() {
             panic!("already initialized mecab");
         }
-        #[allow(clippy::uninit_assumed_init)]
-        let mut m: open_jtalk_sys::Mecab = MaybeUninit::uninit().assume_init();
-        let result = bool_number_to_bool(open_jtalk_sys::Mecab_initialize(&mut m));
+        let (result, m) = {
+            let mut m = MaybeUninit::<open_jtalk_sys::Mecab>::uninit();
+            let result = bool_number_to_bool(open_jtalk_sys::Mecab_initialize(m.as_mut_ptr()));
+            (result, m.assume_init())
+        };
         self.0 = Some(m);
         result
     }

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -9,9 +9,11 @@ unsafe impl resources::Resource for Njd {
         if self.0.is_some() {
             panic!("njd already initialized");
         }
-        #[allow(clippy::uninit_assumed_init)]
-        let mut njd: open_jtalk_sys::NJD = MaybeUninit::uninit().assume_init();
-        open_jtalk_sys::NJD_initialize(&mut njd);
+        let njd = {
+            let mut njd = MaybeUninit::<open_jtalk_sys::NJD>::uninit();
+            open_jtalk_sys::NJD_initialize(njd.as_mut_ptr());
+            njd.assume_init()
+        };
         self.0 = Some(njd);
         true
     }


### PR DESCRIPTION
`MaybeUninit::uninit().assume_init()`を撲滅してClippyが通るようにします。

以前は`#[allow]`されていたようですが、今はもうClippyじゃなくてrustc本体からやめろと叫ばれる行為と化しており、かつちゃんと直すことが容易であるため直すことにしました。

`MaybeUninit::uninit().assume_init()`自体のまずさについては、[stdのドキュメント](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#initialization-invariant)のこの例がすべてだと思います。
(型が何であろうと、読み取りをしなくても、uninitializedな値をSafe Rustの世界に迎えたらその時点で本来アウト)

```rust
let x: i32 = unsafe { MaybeUninit::uninit().assume_init() }; // undefined behavior! ⚠️
```
