### PR TITLE
`clippy::cast_ref_to_mut`に準拠する

### DIFF
--- a/crates/open_jtalk/src/mecab/mod.rs
+++ b/crates/open_jtalk/src/mecab/mod.rs
@@ -59,10 +59,14 @@ impl Mecab {
     }
 
     pub fn get_feature_mut(&mut self) -> Option<&mut MecabFeature> {
-        self.get_feature().map(|feature| unsafe {
-            #[allow(clippy::cast_ref_to_mut)]
-            &mut *(feature as *const MecabFeature as *mut MecabFeature)
-        })
+        unsafe {
+            let feature = open_jtalk_sys::Mecab_get_feature(self.as_raw_ptr());
+            if !feature.is_null() {
+                Some(&mut *(feature as *mut MecabFeature))
+            } else {
+                None
+            }
+        }
     }
 
     pub fn analysis(&mut self, str: impl AsRef<str>) -> bool {


### PR DESCRIPTION
[`clippy::cast_ref_to_mut`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_ref_to_mut)に準拠するようにします。

Safe Rustの世界で`&`を`&mut`に変換しようとする行為はまず禁忌であり、それゆえにこのlintは`deny`になっているはずです。

> * Transmuting an `&` to `&mut` is Undefined Behavior. While certain usages may *appear* safe, note that the Rust optimizer is free to assume that a shared reference won't change through its lifetime and thus such transmutation will run afoul of those assumptions. So:
>   * Transmuting an `&` to `&mut` is *always* Undefined Behavior.
>   * No you can't do it.
>   * No you're not special.

[Transmutes - The Rustonomicon](https://doc.rust-lang.org/nomicon/transmutes.html)
