### PR TITLE
`Path`の適切ではないlossyなUTF-8変換をやめる

### DIFF
--- a/crates/open_jtalk-sys/build.rs
+++ b/crates/open_jtalk-sys/build.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     path::{Path, PathBuf},
     process::Command,
+    str,
 };
 fn main() {
     let mut cmake_conf = cmake::Config::new("open_jtalk");
@@ -43,7 +44,8 @@ fn main() {
             .args(["--sdk", sdk, "--show-sdk-path"])
             .output()
             .expect("Failed to run xcrun command");
-        let cmake_osx_sysroot = String::from_utf8_lossy(&cmake_osx_sysroot.stdout)
+        let cmake_osx_sysroot = str::from_utf8(&cmake_osx_sysroot.stdout)
+            .unwrap()
             .trim()
             .to_string();
         cmake_conf.define("CMAKE_OSX_SYSROOT", &cmake_osx_sysroot);
@@ -60,7 +62,7 @@ fn main() {
 
     let dst_dir = cmake_conf.build();
     let lib_dir = dst_dir.join("lib");
-    println!("cargo:rustc-link-search={}", lib_dir.display());
+    println!("cargo:rustc-link-search={}", lib_dir.to_str().unwrap());
     println!("cargo:rustc-link-lib=openjtalk");
     generate_bindings(dst_dir.join("include"), include_dirs.iter());
 }
@@ -80,8 +82,8 @@ fn generate_bindings(
 ) {
     let include_dir = allow_dir.as_ref();
     let clang_args = include_dirs
-        .map(|dir| format!("-I{}", dir.as_ref().display()))
-        .chain([format!("-I{}", include_dir.display())])
+        .map(|dir| format!("-I{}", dir.as_ref().to_str().unwrap()))
+        .chain([format!("-I{}", include_dir.to_str().unwrap())])
         .collect::<Vec<_>>();
     println!("cargo:rerun-if-changed=wrapper.hpp");
     println!("cargo:rerun-if-changed=src/generated/bindings.rs");


### PR DESCRIPTION
まず前提として、Rustの[`Path`](https://doc.rust-lang.org/stable/std/path/struct.Path.html)/[`PathBuf`](https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html)はUTF-8である保証はありません。UTF-8として扱いたくなったときは、次のどちらかを**明示的**に行う必要があります。

1. UTF-8として壊れていたらエラーもしくはクラッシュ
2. UTF-8として壊れている部分を`'�'`に変換してUTF-8とする

本PRは2.の変換をしている部分を1.の形に置き換えます。

個人的な意見としては2.はメッセージ出力のみに限定されるべきで、実際にファイル操作に使うパスの文字列加工の過程で使われるべきではないと思います。

またvoicevox\_coreは一貫して1.だったと思います。このリポジトリだと混在している状態ではありますが、 #9 以前には2.の形は1箇所しか無く、残りはすべて1.の形であるように見えました。
