### PR TITLE
`workspace.resolver`を設定

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crates/open_jtalk-sys", "crates/open_jtalk"]
+resolver = "2"


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/pull/646>と同内容です。Cargoのあらゆるコマンドの実行時にwarningが出る状態に今なっているので、それの解消が目的です。

## 関連 Issue

## スクリーンショット・動画など

## その他
