### PR TITLE
`unsafe impl Send for {Mecab,Njd,JpCommon}`

### DIFF
--- a/crates/open_jtalk/src/jpcommon.rs
+++ b/crates/open_jtalk/src/jpcommon.rs
@@ -32,6 +32,9 @@ unsafe impl resources::Resource for JpCommon {
     }
 }
 
+// SAFETY: `Send`と対立する性質はないはず。
+unsafe impl Send for JpCommon {}
+
 impl<'a> Iterator for JpCommonLabelFeatureIter<'a> {
     type Item = &'a str;
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/open_jtalk/src/mecab/mod.rs
+++ b/crates/open_jtalk/src/mecab/mod.rs
@@ -39,6 +39,9 @@ unsafe impl resources::Resource for Mecab {
     }
 }
 
+// SAFETY: `Send`と対立する性質はないはず。
+unsafe impl Send for Mecab {}
+
 impl Mecab {
     unsafe fn as_raw_ptr(&self) -> *mut open_jtalk_sys::Mecab {
         if self.0.is_none() {

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -24,6 +24,9 @@ unsafe impl resources::Resource for Njd {
     }
 }
 
+// SAFETY: `Send`と対立する性質はないはず。
+unsafe impl Send for Njd {}
+
 impl Njd {
     pub(crate) unsafe fn as_raw_ptr(&self) -> *mut open_jtalk_sys::NJD {
         if self.0.is_none() {


### PR DESCRIPTION
## 内容

COREの以下の部分の役目を、こちら側に移します。

<https://github.com/VOICEVOX/voicevox_core/blob/fa630ce9596103e00b78049bf5c0db0e078c125e/crates/voicevox_core/src/engine/open_jtalk.rs#L185-L187>

## 関連 Issue

## スクリーンショット・動画など

## その他
