### PR TITLE
feat: add `Njd::update`

### DIFF
--- a/crates/open_jtalk/Cargo.toml
+++ b/crates/open_jtalk/Cargo.toml
@@ -6,7 +6,6 @@ license = "BSD-3-Clause"
 
 [dependencies]
 camino = "1.1.6"
-itertools = "0.14.0"
 libc = "0.2.176"
 open_jtalk-sys = { path = "../open_jtalk-sys", version = "0.16.111" }
 thiserror = "1.0.31"

--- a/crates/open_jtalk/Cargo.toml
+++ b/crates/open_jtalk/Cargo.toml
@@ -6,6 +6,8 @@ license = "BSD-3-Clause"
 
 [dependencies]
 camino = "1.1.6"
+itertools = "0.14.0"
+libc = "0.2.176"
 open_jtalk-sys = { path = "../open_jtalk-sys", version = "0.16.111" }
 thiserror = "1.0.31"
 

--- a/crates/open_jtalk/Cargo.toml
+++ b/crates/open_jtalk/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 camino = "1.1.6"
-libc = "0.2.176"
+libc = "0.2.159"
 open_jtalk-sys = { path = "../open_jtalk-sys", version = "0.16.111" }
 thiserror = "1.0.31"
 

--- a/crates/open_jtalk/Cargo.toml
+++ b/crates/open_jtalk/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 camino = "1.1.6"
-libc = "0.2.159"
+libc = "0.2.176"
 open_jtalk-sys = { path = "../open_jtalk-sys", version = "0.16.111" }
 thiserror = "1.0.31"
 

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -12,10 +12,10 @@ use super::*;
 pub use self::string::Utf8LibcString;
 
 #[cfg(target_env = "msvc")]
-const MAX_ALIGN: usize = mem::size_of::<size_t>();
+const MAX_ALIGN: usize = mem::align_of::<size_t>();
 
 #[cfg(not(target_env = "msvc"))]
-const MAX_ALIGN: usize = mem::size_of::<libc::max_align_t>();
+const MAX_ALIGN: usize = mem::align_of::<libc::max_align_t>();
 
 #[derive(Default)]
 pub struct Njd(Option<open_jtalk_sys::NJD>);

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -245,9 +245,11 @@ impl NjdNode {
 
         let buf = malloc(mem::size_of::<open_jtalk_sys::NJDNode>()).cast();
         unsafe {
-            // SAFETY: `malloc` correctly allocates enough memory.
-            const _: () =
-                assert!(mem::align_of::<open_jtalk_sys::NJDNode>() == mem::size_of::<usize>());
+            // SAFETY: `malloc` correctly allocates enough aligned memory.
+            const _: () = assert!(
+                mem::align_of::<open_jtalk_sys::NJDNode>() <= mem::size_of::<usize>()
+                    || mem::align_of::<open_jtalk_sys::NJDNode>() <= mem::size_of::<c_int>()
+            );
             buf.write(raw);
         }
         return buf;

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -101,8 +101,8 @@ impl Njd {
                 Vec::with_capacity(unsafe { open_jtalk_sys::NJD_get_size(this.as_ptr()) } as _);
 
             let this = unsafe {
-                // SAFETY: `raw` should be valid for read/write since `&mut self` is held and all
-                // other functions should not leave `this` broken. It should be also aligned
+                // SAFETY: `this` should be valid for write since we are holding `&mut self` here
+                // and all other functions should not leave `this` broken. It should be also aligned
                 // because it comes from `malloc`.
                 const _: () = assert!(mem::align_of::<open_jtalk_sys::NJD>() <= MAX_ALIGN);
                 this.as_mut()

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -44,6 +44,7 @@ unsafe impl resources::Resource for Njd {
 unsafe impl Send for Njd {}
 
 impl Njd {
+    // TODO: この関数自体は事前条件を持たないはずなので、`unsafe`じゃなくてもいいはず
     pub(crate) unsafe fn as_raw_ptr(&self) -> *mut open_jtalk_sys::NJD {
         if self.0.is_none() {
             panic!("uninitialized njd");

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -9,7 +9,7 @@ use libc::size_t;
 
 use super::*;
 
-pub use self::string::LibcUtf8String;
+pub use self::string::Utf8LibcString;
 
 #[derive(Default)]
 pub struct Njd(Option<open_jtalk_sys::NJD>);
@@ -135,19 +135,19 @@ impl Njd {
 
 #[derive(Debug)]
 pub struct NjdNode {
-    pub string: Option<LibcUtf8String>,
-    pub pos: Option<LibcUtf8String>,
-    pub pos_group1: Option<LibcUtf8String>,
-    pub pos_group2: Option<LibcUtf8String>,
-    pub pos_group3: Option<LibcUtf8String>,
-    pub ctype: Option<LibcUtf8String>,
-    pub cform: Option<LibcUtf8String>,
-    pub orig: Option<LibcUtf8String>,
-    pub read: Option<LibcUtf8String>,
-    pub pron: Option<LibcUtf8String>,
+    pub string: Option<Utf8LibcString>,
+    pub pos: Option<Utf8LibcString>,
+    pub pos_group1: Option<Utf8LibcString>,
+    pub pos_group2: Option<Utf8LibcString>,
+    pub pos_group3: Option<Utf8LibcString>,
+    pub ctype: Option<Utf8LibcString>,
+    pub cform: Option<Utf8LibcString>,
+    pub orig: Option<Utf8LibcString>,
+    pub read: Option<Utf8LibcString>,
+    pub pron: Option<Utf8LibcString>,
     pub acc: c_int,
     pub mora_size: c_int,
-    pub chain_rule: Option<LibcUtf8String>,
+    pub chain_rule: Option<Utf8LibcString>,
     pub chain_flag: c_int,
 }
 
@@ -201,8 +201,8 @@ impl NjdNode {
 
         return this;
 
-        fn from_raw(s: *mut c_char) -> Option<LibcUtf8String> {
-            NonNull::new(s).map(LibcUtf8String::from_raw)
+        fn from_raw(s: *mut c_char) -> Option<Utf8LibcString> {
+            NonNull::new(s).map(Utf8LibcString::from_raw)
         }
     }
 
@@ -252,8 +252,8 @@ impl NjdNode {
         }
         return buf;
 
-        fn into_raw(s: Option<LibcUtf8String>) -> *mut c_char {
-            s.map(LibcUtf8String::into_raw).unwrap_or_default()
+        fn into_raw(s: Option<Utf8LibcString>) -> *mut c_char {
+            s.map(Utf8LibcString::into_raw).unwrap_or_default()
         }
     }
 }
@@ -273,10 +273,10 @@ mod string {
         ptr::NonNull,
     };
 
-    pub struct LibcUtf8String(NonNull<c_char>);
+    pub struct Utf8LibcString(NonNull<c_char>);
 
-    impl LibcUtf8String {
-        /// Creates a new `LibcUtf8String`.
+    impl Utf8LibcString {
+        /// Creates a new `Utf8LibcString`.
         ///
         /// # Panics
         ///
@@ -314,7 +314,7 @@ mod string {
         }
     }
 
-    impl Drop for LibcUtf8String {
+    impl Drop for Utf8LibcString {
         fn drop(&mut self) {
             // SAFETY: `self.0` is valid, and is exposed only in `Self::as_str`, `Self::into_raw`,
             // and this `Drop` implementation.
@@ -322,19 +322,19 @@ mod string {
         }
     }
 
-    impl AsRef<str> for LibcUtf8String {
+    impl AsRef<str> for Utf8LibcString {
         fn as_ref(&self) -> &str {
             self.as_str()
         }
     }
 
-    impl PartialEq<str> for LibcUtf8String {
+    impl PartialEq<str> for Utf8LibcString {
         fn eq(&self, other: &str) -> bool {
             self.as_str() == other
         }
     }
 
-    impl Debug for LibcUtf8String {
+    impl Debug for Utf8LibcString {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             write!(f, "{:?}", self.as_str())
         }

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -12,7 +12,7 @@ use super::*;
 pub use self::string::Utf8LibcString;
 
 #[cfg(target_env = "msvc")]
-const MAX_ALIGN: usize = mem::align_of::<size_t>();
+const MAX_ALIGN: usize = mem::align_of::<std::ffi::c_double>();
 
 #[cfg(not(target_env = "msvc"))]
 const MAX_ALIGN: usize = mem::align_of::<libc::max_align_t>();

--- a/crates/open_jtalk/src/njd.rs
+++ b/crates/open_jtalk/src/njd.rs
@@ -260,7 +260,8 @@ impl NjdNode {
         return buf;
 
         fn into_raw(s: Option<Utf8LibcString>) -> *mut c_char {
-            s.map(Utf8LibcString::into_raw).unwrap_or_default()
+            // TODO: Rust 1.88以降にしたら`unwrap_or_default`に
+            s.map(Utf8LibcString::into_raw).unwrap_or(ptr::null_mut())
         }
     }
 }


### PR DESCRIPTION
## 内容

ENGINEにおける`pyopenjtalk.run_frontend`からの`NJDNode`の編集と同じことを行えるようにする。

VOICEVOX/voicevox_core#1161 の実装に必要。

## 関連 Issue

## スクリーンショット・動画など

## その他
