### PR TITLE
chore: revive the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
       - uses: Swatinem/rust-cache@v1
       - run: cargo clippy --all-features --tests -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
@@ -15,12 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
           - os: windows-2022
+          - os: windows-2025
           - os: macos-13
           - os: macos-14
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
+          - os: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797

--- a/crates/open_jtalk/src/jpcommon.rs
+++ b/crates/open_jtalk/src/jpcommon.rs
@@ -76,7 +76,7 @@ impl JpCommon {
         unsafe { open_jtalk_sys::njd2jpcommon(self.as_raw_ptr(), njd.as_raw_ptr()) }
     }
 
-    pub fn get_label_feature_to_iter(&self) -> Option<JpCommonLabelFeatureIter> {
+    pub fn get_label_feature_to_iter(&self) -> Option<JpCommonLabelFeatureIter<'_>> {
         self.get_label_feature_raw().map(|label_features| {
             let label_features_size = self.get_label_size();
             JpCommonLabelFeatureIter {


### PR DESCRIPTION
## 内容

1. [`mismatched_lifetime_syntaxes`警告](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html)の対応。
2. CIを復旧させる。ただ`macos-13`とか`actions/checkout@1`とかが色々残っていて、actionlintすら激怒している状態だが、それらについては一旦見なかったことにして #34 を優先する。

## 関連 Issue

## スクリーンショット・動画など

## その他
