### PR TITLE
ci: macOS runner の macos-13 をアップデート

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
         include:
           - os: windows-2022
           - os: windows-2025
-          - os: macos-13
           - os: macos-14
+          - os: macos-15
           - os: ubuntu-22.04
           - os: ubuntu-24.04
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 内容

macOS 13 runnerが2025年12月4日に廃止されるため、macOS runnerを `macos-13` から `macos-15` にアップデートします。

現在 `macos-14` と `macos-15` の両方のARMランナーでテストを実行します。

## 関連 Issue

GitHub Actionsの公式アナウンスに対応:
https://github.com/actions/runner-images/issues/11083

## スクリーンショット・動画など

N/A

## その他

この変更により、macOS 14と15の両方でテストを実行し、より広範なmacOSバージョンでの互換性を確保します。