### PR TITLE
chore(sys): bump bindgen to v0.72.0

### DIFF
--- a/crates/open_jtalk-sys/Cargo.toml
+++ b/crates/open_jtalk-sys/Cargo.toml
@@ -10,7 +10,7 @@ generate-bindings = []
 
 [build-dependencies]
 cmake = "0.1.48"
-bindgen = "0.70.1"
+bindgen = "0.72.0"
 
 [dependencies]
 link-cplusplus = "1.0.6"


### PR DESCRIPTION
## 内容

`open_jtalk-sys`クレートのedition 2024化を阻害するため。`open_jtalk`クレートだけ2024化ということもできはするが、bindgenを上げればいいだけの話なので上げてしまう。

新しいbindgenには rust-lang/rust-bindgen#2932 が入っているが、ビルド時にはbindgenを起動することがない我々には影響しない認識。
