### PR TITLE
chore: `contents=read`化で動かなくなった`gen_bind`を直す

### DIFF
--- a/.github/workflows/gen_bind.yml
+++ b/.github/workflows/gen_bind.yml
@@ -38,6 +38,9 @@ jobs:
           - os: macos-latest
             triple: x86_64-apple-ios
     runs-on: ${{ matrix.target.os }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_project#93 によりVOICEVOX下で`gen_bind`が動かなくなったので、`permissions`を明示する。

## その他

このPRをマージするのは @sabonerune さんによるバインディング更新の後がよさそう。
