### PR TITLE
ci: `audit`の中身をcargo-denyにし、`schedule`実行に

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,19 +1,30 @@
+# 依存ライブラリを監査する。
+#
+# RustSec Advisory Databaseに登録された、あるいは単にヤンクされたクレートを検出する。
+# 検出されるものは脆弱性（`vulnerability`）のみとは限らない。
+# 依存ライブラリが単に"unmaintained"とされたりヤンクされたりしても反応する。
+
 name: Security audit
+
+# データベースへの登録とクレートのヤンクはこちらの依存ライブラリの編集と関係なく起きるため、`push`
+# と`pull_request`はトリガーにしない。
 on:
-  push:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-  pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 * * *'
 
 jobs:
-  security_audit:
+  audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-binstall
+      - name: Install cargo-deny
+        shell: bash
+        run: cargo binstall cargo-deny@^0.20 --no-confirm --log-level debug
+      - name: cargo-deny
+        run: cargo deny check -s advisories

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,14 @@
+[graph]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_core#328 および VOICEVOX/voicevox_core#893 と同じ理由。今やる理由としては、 VOICEVOX/voicevox_project#93 の対応で`permissions`を指定しなければならない「かも」しれず、判断が面倒くさくなったから。

COREの`check-release-target-tuples`のようなCIを用意しようとも考えたが、漏れがあったところでさほど致命的ではなさそうなので放置。
